### PR TITLE
hcdoc, gcfestus, gclennty: fix incorrect time advances

### DIFF
--- a/scripts_src/brokhill/hcdoc.ssl
+++ b/scripts_src/brokhill/hcdoc.ssl
@@ -645,7 +645,7 @@ procedure Node021 begin
    critter_heal(dude_obj,dude_max_hits-dude_cur_hits);
    critter_uninjure(dude_obj, (DAM_CRIP_LEG_LEFT bwor DAM_CRIP_LEG_RIGHT bwor DAM_CRIP_ARM_LEFT bwor DAM_CRIP_ARM_RIGHT));
    gfade_out(600);
-   game_time_advance(game_ticks(2*ONE_GAME_HOUR));//Heal Damage
+   game_time_advance(2*ONE_GAME_HOUR);//Heal Damage
    gfade_in(600);
    // End Seraph's Code
    Reply(170); //check doc NBK
@@ -734,7 +734,7 @@ end
 
 procedure Node029a begin
    gfade_out(600);
-   game_time_advance(game_ticks(party_size*ONE_GAME_HOUR));//Heal Injure
+   game_time_advance(party_size*ONE_GAME_HOUR);//Heal Injure
    gfade_in(600);
 
    Reply(315);
@@ -1063,9 +1063,9 @@ procedure PayDude begin
       gfade_out(600);
 
       if( Heal_Cost == 300 ) then
-         game_time_advance(game_ticks(8*ONE_GAME_HOUR));//Heal Injure
+         game_time_advance(8*ONE_GAME_HOUR);//Heal Injure
       else
-         game_time_advance(game_ticks(2*ONE_GAME_HOUR));//Heal Damage
+         game_time_advance(2*ONE_GAME_HOUR);//Heal Damage
 
       gfade_in(600);
 
@@ -1086,9 +1086,9 @@ procedure PayParty begin
       gfade_out(600);
 
       if( Heal_Cost == 300 ) then
-         game_time_advance(game_ticks(8*ONE_GAME_HOUR));//Heal Injure
+         game_time_advance(8*ONE_GAME_HOUR);//Heal Injure
       else
-         game_time_advance(game_ticks(2*ONE_GAME_HOUR));//Heal Dammage
+         game_time_advance(2*ONE_GAME_HOUR);//Heal Dammage
 
       gfade_in(600);
 

--- a/scripts_src/gecko/gcfestus.ssl
+++ b/scripts_src/gecko/gcfestus.ssl
@@ -379,7 +379,7 @@ end
 procedure Node910 begin
    ndebug("Node910");
    gfade_out(600);
-   game_time_advance(game_ticks(k*360)); //6 minutes
+   game_time_advance(6 * ONE_GAME_MINUTE);
    gfade_in(600);
    display_msg(mstr(500));
 end
@@ -387,7 +387,7 @@ end
 procedure Node912 begin
    ndebug("Node912");
    gfade_out(600);
-   game_time_advance(game_ticks(k*1080)); //18 minutes
+   game_time_advance(18 * ONE_GAME_MINUTE);
    gfade_in(600);
    display_msg(mstr(530));
 end
@@ -1054,7 +1054,7 @@ end
 procedure Node060 begin
    ndebug("Node060");
    gfade_out(600);
-   game_time_advance(game_ticks(k*360)); //6 minutes
+   game_time_advance(6 * ONE_GAME_MINUTE);
    gfade_in(600);
    Reply(640);
    NOption(650,Node999,004);

--- a/scripts_src/gecko/gclenny.ssl
+++ b/scripts_src/gecko/gclenny.ssl
@@ -502,7 +502,7 @@ procedure HealPlayer begin
       critter_uninjure(dude_obj, (DAM_CRIP_LEG_LEFT bwor DAM_CRIP_LEG_RIGHT bwor DAM_CRIP_ARM_LEFT bwor DAM_CRIP_ARM_RIGHT));
    end
    gfade_out(600);
-      game_time_advance(game_ticks(8*ONE_GAME_HOUR));//Heal Injure or mult npcs
+      game_time_advance(8 * ONE_GAME_HOUR); // Heal Injure or mult npcs
    gfade_in(600);
 end
 
@@ -749,7 +749,7 @@ procedure PartyFree begin
    if (k > 1) then
       Heal_Cost:=60;
    gfade_out(600);
-      game_time_advance(game_ticks(8*ONE_GAME_HOUR));//Heal Injure or mult npcs
+      game_time_advance(8 * ONE_GAME_HOUR); // Heal Injure or mult npcs
    gfade_in(600);
 end
 


### PR DESCRIPTION
- Fix instances of time being converted to ticks twice, resulting in 10x time advances