### PR TITLE
Minor edits to the installer

### DIFF
--- a/extra/inno/ini_qol.iss
+++ b/extra/inno/ini_qol.iss
@@ -10,7 +10,6 @@ FileName: "{app}\ddraw.ini"; Section: "Misc"; Key: "PartyMemberExtraInfo"; Strin
 FileName: "{app}\ddraw.ini"; Section: "Misc"; Key: "PlayIdleAnimOnReload"; String: "1"; Components: qol;
 FileName: "{app}\ddraw.ini"; Section: "Misc"; Key: "SpeedInventoryPCRotation"; String: "800"; Components: qol;
 FileName: "{app}\ddraw.ini"; Section: "Misc"; Key: "SpeedInterfaceCounterAnims"; String: "2"; Components: qol;
-FileName: "{app}\ddraw.ini"; Section: "Misc"; Key: "StackEmptyWeapons"; String: "1"; Components: qol;
 FileName: "{app}\ddraw.ini"; Section: "Misc"; Key: "WorldMapFontPatch"; String: "1"; Components: qol;
 
 FileName: "{app}\ddraw.ini"; Section: "Sound"; Key: "NumSoundBuffers"; String: "32"; Components: qol;

--- a/extra/inno/inno.iss
+++ b/extra/inno/inno.iss
@@ -13,6 +13,7 @@ AppPublisher=BGforge
 AppPublisherURL=https://bgforge.net
 AppSupportURL=https://forums.bgforge.net/viewforum.php?f=34
 AppUpdatesURL=https://github.com/BGforgeNet/Fallout2_Restoration_Project
+VersionInfoTextVersion=2.3.3{#uversion}
 DefaultDirName=C:\Games\Fallout2
 AppendDefaultDirName=no
 DisableProgramGroupPage=yes


### PR DESCRIPTION
* StackEmptyWeapons is removed from ini (always on) since sfall 4.3.8.
* Add "product version" string to the installer properties (superficial, but original RP installer has version string set so why not).
![instprop](https://github.com/BGforgeNet/Fallout2_Unofficial_Patch/assets/8564973/0ec6cce6-f5ee-4b97-ad12-3800d0a4352c)