### PR TITLE
Make more RPU components optional for exe installer

### DIFF
--- a/extra/inno/inno.iss
+++ b/extra/inno/inno.iss
@@ -30,6 +30,13 @@ AlwaysShowDirOnReadyPage=yes
 [Files]
 Source: "release\*.*"; DestDir: "{app}"; Components: core; Flags: ignoreversion recursesubdirs overwritereadonly
 #include "files_translations.iss"
+Source: "optional\rpu_enhanced_worldmap.dat"; DestDir: "{#mods_dir}"; Components: worldmap; Flags: ignoreversion overwritereadonly
+Source: "optional\rpu_rifle_animations.dat"; DestDir: "{#mods_dir}"; Components: wpn_anims\rifle; Flags: ignoreversion overwritereadonly
+Source: "optional\rpu_wakizashi_animations.dat"; DestDir: "{#mods_dir}"; Components: wpn_anims\wakizashi; Flags: ignoreversion overwritereadonly
+Source: "optional\rpu_extended_flamer.dat"; DestDir: "{#mods_dir}"; Components: wpn_anims\ext_flamer; Flags: ignoreversion overwritereadonly
+Source: "optional\cassidy_head.dat"; DestDir: "{#mods_dir}"; Components: cassidy_head; Flags: ignoreversion overwritereadonly
+Source: "optional\cassidy_voice_joey_bracken_hq.dat"; DestDir: "{#mods_dir}"; Components: cassidy_head; Flags: ignoreversion overwritereadonly
+Source: "optional\rpu_improved_mysterious_stranger.dat"; DestDir: "{#mods_dir}"; Components: imp_stranger; Flags: ignoreversion overwritereadonly
 Source: "optional\walk_speed_fix_low_fps.dat"; DestDir: "{#mods_dir}"; Components: walk_speed\low_fps; Flags: ignoreversion overwritereadonly
 Source: "optional\goris_fast_derobing_low_fps.dat"; DestDir: "{#mods_dir}"; Components: goris\low_fps; Flags: ignoreversion overwritereadonly
 
@@ -50,6 +57,17 @@ Filename: "{app}\{#basename}-install.bat"; Parameters: "> {#backup_dir}\log.txt 
 [Components]
 Name: "core"; Description: "Core"; Types: "custom"; Flags: fixed;
 Name: "qol"; Description: "Enable sfall QoL features"; Types: "custom";
+
+Name: "worldmap"; Description: "Visually enhanced world map"; Types: "custom";  Flags: disablenouninstallwarning
+
+Name: "wpn_anims"; Description: "Weapon animations"; Types: "custom"
+Name: "wpn_anims\rifle"; Description: "New rifle animations"; Types: "custom"; Flags: disablenouninstallwarning;
+Name: "wpn_anims\wakizashi"; Description: "New wakizashi blade animations"; Types: "custom"; Flags: disablenouninstallwarning;
+Name: "wpn_anims\ext_flamer"; Description: "Extended flamer attack animations"; Types: "custom"; Flags: disablenouninstallwarning;
+
+Name: "cassidy_head"; Description: "Talking head and voice for Cassidy"; Types: "custom"; Flags: disablenouninstallwarning;
+
+Name: "imp_stranger"; Description: "Improved Mysterious Stranger"; Types: "custom";  Flags: disablenouninstallwarning
 
 Name: "walk_speed"; Description: "Walk speed fix"; Types: "custom";
 Name: "walk_speed\high_fps"; Description: "High FPS"; Flags: exclusive disablenouninstallwarning;

--- a/extra/package/inno.sh
+++ b/extra/package/inno.sh
@@ -20,6 +20,16 @@ cp -r $release_dir ./
 mkdir translations
 mv $trans_dir/*.dat translations/
 
+# move optional components
+mkdir optional
+mv ./release/mods/rpu_enhanced_worldmap.dat optional/
+mv ./release/mods/rpu_rifle_animations.dat optional/
+mv ./release/mods/rpu_wakizashi_animations.dat optional/
+mv ./release/mods/rpu_extended_flamer.dat optional/
+mv ./release/mods/cassidy_head.dat optional/
+mv ./release/mods/cassidy_voice_joey_bracken_hq.dat optional/
+mv ./release/mods/rpu_improved_mysterious_stranger.dat optional/
+
 # alternative animations, not included into manual install
 "$extra_dir"/package/animation_fixes.sh
 


### PR DESCRIPTION
Partially related to #239. I change more individual .dat components to optional, leaving only NPC armor appearance and party order as core components.

Comparing to the original RP 2.3.3 installer:
* black: not optional
* red: ini settings in `rpu.ini`
* blue: already optional
* green: changed to optional by this commit

![rp233_insts](https://github.com/BGforgeNet/Fallout2_Restoration_Project/assets/8564973/a728af54-88ba-45da-bc7a-bae597dcba04)
