### PR TITLE
Rearrange components for the installer

### DIFF
--- a/extra/inno/components_ammo.iss
+++ b/extra/inno/components_ammo.iss
@@ -1,4 +1,4 @@
-Name: "ammo"; Description: "Ammo damage formula"; Types: "custom";
+Name: "ammo"; Description: "Ammo damage formula"; Types: "custom"; Flags: fixed;
 Name: "ammo\default"; Description: "Default"; Flags: exclusive disablenouninstallwarning;
 Name: "ammo\glovz"; Description: "Glovz's"; Flags: exclusive disablenouninstallwarning;
 Name: "ammo\yaam"; Description: "YAAM"; Flags: exclusive disablenouninstallwarning;

--- a/extra/inno/inno.iss
+++ b/extra/inno/inno.iss
@@ -55,10 +55,6 @@ Filename: "{app}\{#basename}-install.bat"; Parameters: "> {#backup_dir}\log.txt 
 
 [Components]
 Name: "core"; Description: "Core"; Types: "custom"; Flags: fixed;
-Name: "qol"; Description: "Enable sfall QoL features"; Types: "custom";
-
-#include "components_ammo.iss"
-
 Name: "translation"; Description: "Language"; Types: "custom"; Flags: fixed;
 #include "components_translations.iss"
 
@@ -69,6 +65,10 @@ Name: "walk_speed\low_fps"; Description: "Low FPS"; Flags: exclusive disablenoun
 Name: "goris"; Description: "Faster derobing for Goris"; Types: "custom";
 Name: "goris\high_fps"; Description: "High FPS"; Flags: exclusive disablenouninstallwarning;
 Name: "goris\low_fps"; Description: "Low FPS"; Flags: exclusive disablenouninstallwarning;
+
+#include "components_ammo.iss"
+
+Name: "qol"; Description: "Enable sfall QoL features"; Types: "custom";
 
 Name: "worldmap"; Description: "Visually enhanced world map"; Types: "custom";  Flags: disablenouninstallwarning
 

--- a/extra/inno/inno.iss
+++ b/extra/inno/inno.iss
@@ -58,6 +58,8 @@ Name: "core"; Description: "Core"; Types: "custom"; Flags: fixed;
 Name: "translation"; Description: "Language"; Types: "custom"; Flags: fixed;
 #include "components_translations.iss"
 
+#include "components_ammo.iss"
+
 Name: "walk_speed"; Description: "Walk speed fix"; Types: "custom";
 Name: "walk_speed\high_fps"; Description: "High FPS"; Flags: exclusive disablenouninstallwarning;
 Name: "walk_speed\low_fps"; Description: "Low FPS"; Flags: exclusive disablenouninstallwarning;
@@ -65,8 +67,6 @@ Name: "walk_speed\low_fps"; Description: "Low FPS"; Flags: exclusive disablenoun
 Name: "goris"; Description: "Faster derobing for Goris"; Types: "custom";
 Name: "goris\high_fps"; Description: "High FPS"; Flags: exclusive disablenouninstallwarning;
 Name: "goris\low_fps"; Description: "Low FPS"; Flags: exclusive disablenouninstallwarning;
-
-#include "components_ammo.iss"
 
 Name: "qol"; Description: "Enable sfall QoL features"; Types: "custom";
 


### PR DESCRIPTION
Left - previous, Right - this PR.
![rpu_instx](https://github.com/BGforgeNet/Fallout2_Restoration_Project/assets/8564973/ec7c492b-3d73-4957-8197-2ddf59c84935)

IMO language packs are more important than other optional components, and followed by the three radio button options, then the rest of checkbox options. Come to think of it, maybe add the "fixed" flag to "Ammo damage formula" checkbox? Since it's more like language packs that the main checkbox has no actual use.