### PR TITLE
Fixed the submarine quest active again after killing the dock guard

### DIFF
--- a/scripts_src/sanfran/fcdokgrd.ssl
+++ b/scripts_src/sanfran/fcdokgrd.ssl
@@ -196,7 +196,9 @@ procedure destroy_p_proc begin
    inc_good_critter
    boatGrd_ptr := 0;
    set_map_var(MVAR_Use_Motor_Boat,0);
-   set_sub_flag(SHI_SUB_ALONE);
+   if (global_var(GVAR_SAN_FRAN_SUB) < SHI_SUB_DISABLED) then begin
+      set_sub_flag(SHI_SUB_ALONE);
+   end
 /* Set global_variable for Enemy status*/
 end
 


### PR DESCRIPTION
Saw [a new bug report on the wiki](https://falloutmods.fandom.com/wiki/Restoration_Project_bug_reports#Submarine):
> Once disabling the submarine then killing the dock guard, the quest becomes active again, preventing you from leaving with the tanker. Since you can't re-enter the submarine, this makes the game impossible to finish.

While actually it's still possible to return to the submarine (using lockpick or blowing up the hatch) and disable it for the second time, it's obviously pointless to let the quest active again.