### PR TITLE
Fix VC Entrance_Door_Ptr

### DIFF
--- a/scripts_src/abbey/abbey.ssl
+++ b/scripts_src/abbey/abbey.ssl
@@ -17,7 +17,14 @@ procedure start;
 procedure map_enter_p_proc;
 procedure map_update_p_proc;
 
+/*
+  TODO: this is a temporary workaround for a ghost object in .map file.
+  It should be removed once the map file is fixed.
+  See https://github.com/BGforgeNet/Fallout2_Restoration_Project/pull/260
+*/
 export variable playerTmpBox2;
+/* end todo */
+
 export variable abbey_bill_box_obj;
 
 procedure start

--- a/scripts_src/maps/ncr2.ssl
+++ b/scripts_src/maps/ncr2.ssl
@@ -45,8 +45,14 @@ export variable i_locker_tamper     := 0;
 export variable i_fergus_obj        := 0;
 export variable i_gunther_obj       := 0;
 export variable i_emitter_carlson_obj := 0;
-export variable lenny_obj     := 0;
 
+/*
+  TODO: this is a temporary workaround for a ghost object in .map file.
+  It should be removed once the map file is fixed.
+  See https://github.com/BGforgeNet/Fallout2_Restoration_Project/pull/260
+*/
+export variable lenny_obj     := 0;
+/* end todo */
 
 procedure start;
 procedure map_enter_p_proc;

--- a/scripts_src/maps/vctyctyd.ssl
+++ b/scripts_src/maps/vctyctyd.ssl
@@ -19,6 +19,7 @@ procedure start;
 procedure map_enter_p_proc;
 procedure map_update_p_proc;
 
+export variable Entrance_Door_Ptr;
 export variable vault_city_harry_box;
 export variable vault_city_courtyard_temp_box;
 export variable plow1;

--- a/scripts_src/maps/vctyctyd.ssl
+++ b/scripts_src/maps/vctyctyd.ssl
@@ -19,7 +19,14 @@ procedure start;
 procedure map_enter_p_proc;
 procedure map_update_p_proc;
 
+/*
+  TODO: this is a temporary workaround for a ghost object in .map file.
+  It should be removed once the map file is fixed.
+  See https://github.com/BGforgeNet/Fallout2_Restoration_Project/pull/260
+*/
 export variable Entrance_Door_Ptr;
+/* end todo */
+
 export variable vault_city_harry_box;
 export variable vault_city_courtyard_temp_box;
 export variable plow1;


### PR DESCRIPTION
Fix an annoying crash with a kind of "An illegal instruction was executed at address ..." when entering Vault City (may be other locations too, but this is the first I faced during my play).

Background: 
The error bothers a lot of players, but seems [tweakable](https://github.com/BGforgeNet/Fallout2_Restoration_Project/issues/171#issuecomment-1689799910) for Windows users.
For Mac/Linux wine players, this is not an option.

Debug of the crash:
```
...
Error during execution: External variable Entrance_Door_Ptr does not exist

Current script: scripts\vientdor.int, procedure map_update_p_proc
```

I'm not a fallout resource expert, but looks like the problem was with the lack of exporting this var. I have started with Fallout Explorer (or something cheat) to move the dude to the Vault City Downtown. This worked. But every time  I tried to enter the courtyard, the game crashed. After a quick src examination, the solution came up.
Built and tested through GitHub actions, no more errors for VC.

Tested on Fallout 2 GOG 1.02d
RP 2.3.3u28
sfall 4.4.0.1

mods (pretty standard for clean gog + RP installation through exe):
```
cassidy_head.dat
cassidy_voice_joey_bracken_hq.dat
f2_res.dat
npc_armor.dat
party_orders.dat
rpu.dat
rpu_enhanced_worldmap.dat
rpu_extended_flamer.dat
rpu_improved_mysterious_stranger.dat
rpu_rifle_animations.dat
rpu_wakizashi_animations.dat
```

Runtime:
mac on m2
crossover with win10 bottle (crossover uses their own fork of wine, so results can be different for vanilla wine)

The only problem observed is that if I try to load `fo2tweaks.dat` and `healing_revision` enabled, this will crash with an error in the corresponding global script. But this is another story.


UPD:

One more similar bug was found for the Abbey entrance and included in this PR. After that, I checked all the cities available. Seems no more problems like this. Only one, not related to the original problem, with the village between VC and Gecko (I don't remember it in the original game.), and yet have no idea about the nature of this error in the context of the game, probably one of the mod problem again:

```
Script Error: scripts\bcdalia.int: op_elevation: obj is NULLScript Error: scripts\bcdalia.int: op_critter_add_trait: obj is NULLScript Error: scripts\bcdalia.int: op_critter_add_trait: obj is NULLScript Error: scripts\vcgenvil.int: op_tile_num: obj is NULLScript Error: scripts\vcgenvil.int: op_critter_add_trait: obj is NULLScript Error: scripts\bczeke.int: op_elevation: obj is NULLScript Error: scripts\bczeke.int: op_critter_add_trait: obj is NULLScript Error: scripts\bczeke.int: op_critter_add_trait: obj is NULLScript Error: scripts\vcgenvil.int: op_tile_num: obj is NULLScript Error: scripts\vcgenvil.int: op_critter_add_trait: obj is NULLScript Error: scripts\vcgenvil.int: op_tile_num: obj is NULLScript Error: scripts\vcgenvil.int: op_critter_add_trait: obj is NULLScript Error: scripts\vcconnar.int: op_critter_add_trait: obj is NULLScript Error: scripts\vcconnar.int: op_critter_attempt_placement: obj is NULL
Error during execution: 
Stack underflow short.
Current script: scripts\vcconnar.int, procedure map_enter_p_proc
```