### PR TITLE
EPA holograms: fixed duplicating timer events

### DIFF
--- a/scripts_src/epa/epac4.ssl
+++ b/scripts_src/epa/epac4.ssl
@@ -51,7 +51,6 @@ variable Only_Once := 0;
 
 procedure start
 begin
-  add_timer_event(self_obj, game_ticks(random(4, 7)), 3);
 end
 
 procedure combat_p_proc
@@ -222,6 +221,9 @@ end
 procedure map_enter_p_proc
 begin
   Only_Once := 0;
+  if (not is_loading_game) then begin
+    flush_add_timer_event_sec(self_obj, random(4, 7), 3);
+  end
 end
 
 procedure timed_event_p_proc
@@ -232,7 +234,7 @@ begin
     if (((critter_state(self_obj) bwand 2) == 0) and not combat_is_initialized) then
     begin
       float_msg(self_obj, mstr(random(336, 345)), FLOAT_MSG_RED);
-      add_timer_event(self_obj, game_ticks(random(5, 7)), 3);
+      flush_add_timer_event_sec(self_obj, random(5, 7), 3);
     end
   end
 end

--- a/scripts_src/epa/epac5.ssl
+++ b/scripts_src/epa/epac5.ssl
@@ -42,7 +42,6 @@ variable Only_Once := 0;
 
 procedure start
 begin
-  add_timer_event(self_obj, game_ticks(random(5, 8)), 3);
 end
 
 procedure combat_p_proc
@@ -205,6 +204,9 @@ end
 procedure map_enter_p_proc
 begin
   Only_Once := 0;
+  if (not is_loading_game) then begin
+    flush_add_timer_event_sec(self_obj, random(5, 8), 3);
+  end
 end
 
 procedure timed_event_p_proc
@@ -214,7 +216,7 @@ begin
     if (((critter_state(self_obj) bwand 2) == 0) and not combat_is_initialized) then
     begin
       float_msg(self_obj, mstr(random(244, 253)), FLOAT_MSG_YELLOW);
-      add_timer_event(self_obj, game_ticks(random(5, 6)), 3);
+      flush_add_timer_event_sec(self_obj, random(5, 6), 3);
     end
   end
 end

--- a/scripts_src/epa/epac6.ssl
+++ b/scripts_src/epa/epac6.ssl
@@ -55,7 +55,6 @@ variable Only_Once := 0;
 
 procedure start
 begin
-  add_timer_event(self_obj, game_ticks(random(5, 8)), 3);
 end
 
 procedure combat_p_proc
@@ -218,6 +217,9 @@ end
 procedure map_enter_p_proc
 begin
   Only_Once := 0;
+  if (not is_loading_game) then begin
+    flush_add_timer_event_sec(self_obj, random(5, 8), 3);
+  end
 end
 
 procedure timed_event_p_proc
@@ -227,7 +229,7 @@ begin
     if (((critter_state(self_obj) bwand 2) == 0) and not combat_is_initialized) then
     begin
       float_msg(self_obj, mstr(random(333, 341)), FLOAT_MSG_GREEN);
-      add_timer_event(self_obj, game_ticks(random(5, 6)), 3);
+      flush_add_timer_event_sec(self_obj, random(5, 6), 3);
     end
   end
 end

--- a/scripts_src/epa/epac7.ssl
+++ b/scripts_src/epa/epac7.ssl
@@ -54,7 +54,6 @@ variable Only_Once := 0;
 
 procedure start
 begin
-   add_timer_event(self_obj, game_ticks(random(5, 8)), 3);
 end
 
 procedure combat_p_proc
@@ -217,6 +216,9 @@ end
 procedure map_enter_p_proc
 begin
   Only_Once := 0;
+  if (not is_loading_game) then begin
+    flush_add_timer_event_sec(self_obj, random(5, 8), 3);
+  end
 end
 
 procedure timed_event_p_proc
@@ -226,7 +228,7 @@ begin
     if (((critter_state(self_obj) bwand 2) == 0) and not combat_is_initialized) then
     begin
       float_msg(self_obj, mstr(random(330, 336)), FLOAT_MSG_BLUE);
-      add_timer_event(self_obj, game_ticks(random(5, 6)), 3);
+      flush_add_timer_event_sec(self_obj, random(5, 6), 3);
     end
   end
 end


### PR DESCRIPTION
This fixes holograms spitting multiple floaters at a time, making them hard to read.

start function is called on every map or save load, multiple times even. While all timer events are persistent, they are saved to a save game.