### PR TITLE
Change "self_rep" to "perceived_rep" for more suitable behavior/naming

### DIFF
--- a/scripts_src/brokhill/hcmarcus.ssl
+++ b/scripts_src/brokhill/hcmarcus.ssl
@@ -437,7 +437,7 @@ procedure talk_p_proc begin
       gSay_End;
       end_dialogue;
    end
-   else if (self_rep < -10) then begin
+   else if (perceived_rep < -10) then begin
        start_gdialog(NAME,self_obj,4,HEAD_MARCUS,PartyMemberBackground);
        gSay_Start;
            call Node045;
@@ -634,7 +634,7 @@ procedure Node001a begin
    if ( ( (global_var(GVAR_BH_MINE) == MINE_FIXED_CASH) or (global_var(GVAR_BH_MINE) == MINE_FIXED_FREE) or (global_var(GVAR_BH_MINE) == MINE_REWARDED) ) and
         ( (global_var(GVAR_BH_CONSPIRACY) == CONSPIRACY_BROKEN_DOUBLECROSS) or (global_var(GVAR_BH_CONSPIRACY) == CONSPIRACY_BROKEN_HERO) or
           (global_var(GVAR_BH_JAIL) == JAIL_DOUBLECROSS) or (global_var(GVAR_BH_FTM) == FTM_EXPOSED) ) and
-         self_rep_positive and
+        ( perceived_rep >= 0 ) and
         ( dude_has_free_slot_for_marcus ) ) then
       call Node030;
    else
@@ -1011,7 +1011,7 @@ procedure Node031 begin
       else
          Reply(276);
    end
-   else if self_rep_negative then
+   else if perceived_rep_negative then
       Reply(277);
    else
       Reply(213);
@@ -1400,7 +1400,7 @@ procedure Node1100 begin
       Reply(277);
       BOption(3100, Node999, 001); //added by killap
       BOption(3200, Node999, 001); //added by killap
-   end else if has_rep_childkiller or (self_rep < -100) then begin
+   end else if has_rep_childkiller or (perceived_rep < -100) then begin
       set_self_abandon_party;
       Reply(277);
       BOption(3100, Node999, 001); //added by killap

--- a/scripts_src/den/dcaddict.ssl
+++ b/scripts_src/den/dcaddict.ssl
@@ -277,7 +277,7 @@ procedure Node001 begin
 end
 procedure Node002 begin
    if (heavy_high) then begin
-      floater_rand(201 - self_rep_negative, 212 + self_rep_positive );
+      floater_rand(201 - perceived_rep_negative, 212 + perceived_rep_positive);
    end else if (light_high) then begin
       floater_rand(215 - dude_is_male, 221);
    end else if (light_withdrawal) then begin

--- a/scripts_src/den/dcrebecc.ssl
+++ b/scripts_src/den/dcrebecc.ssl
@@ -352,7 +352,7 @@ procedure Node007 begin
    prev_node := 7;
 end
 procedure Node008 begin
-   if self_rep_negative then begin
+   if perceived_rep_negative then begin
       Reply(350);
    end else if (becky_job(state_becky_job_none)) then begin
       Reply(351 + told_collect);

--- a/scripts_src/den/dcslvgrt.ssl
+++ b/scripts_src/den/dcslvgrt.ssl
@@ -247,7 +247,7 @@ procedure Node002 begin
       BMessage(217);
    end else begin
       set_node_2;
-      Reply(215 + self_rep_negative);
+      Reply(215 + (cult_rep >= 0));
       if (has_rep_slaver == false) then begin
          NOption(218, Node010, 004);
          NOption(221, Node010, -003); //added by killap

--- a/scripts_src/den/dctubfri.ssl
+++ b/scripts_src/den/dctubfri.ssl
@@ -224,9 +224,9 @@ procedure Node002 begin
       end
    end else if ((has_rep_slaver) and (random(0,1))) then begin
       floater_rand(232,235);
-   end else if (check_title_bad(-100) and random(0,1)) then begin
+   end else if (perceived_rep <= -100 and random(0,1)) then begin
       floater(220);
-   end else if (check_title(100) and random(0,1)) then begin
+   end else if (perceived_rep >= 100 and random(0,1)) then begin
       floater(221 + dude_is_female);
    end else begin
       floater_rand(223,231);

--- a/scripts_src/gecko/gclenny.ssl
+++ b/scripts_src/gecko/gclenny.ssl
@@ -826,7 +826,7 @@ procedure Node940 begin
 end
 
 procedure Node951 begin
-   if (self_rep_positive and (local_var(LVAR_reaction) > 30) ) then begin
+   if (perceived_rep_positive and (local_var(LVAR_reaction) > 30) ) then begin
       call Node021;
    end
    else begin

--- a/scripts_src/headers/upu.h
+++ b/scripts_src/headers/upu.h
@@ -150,18 +150,6 @@ end
 #define perceived_rep_positive (perceived_rep > 0)
 #define perceived_rep_negative (perceived_rep < 0)
 
-// normal mode: critter likes dude if he has title, taking Evil_Critter into account
-procedure check_title(variable title) begin
-   variable rep := cult_rep;
-   if self_is_evil then return (rep <= title);
-   else return (rep >= title);
-end
-// inverse mode: critter dislikes dude if he has title, taking Evil_Critter into account
-procedure check_title_bad(variable title) begin
-   variable rep := cult_rep;
-   if self_is_evil then return (rep >= title);
-   else return (rep <= title);
-end
 
 // call before restock
 procedure move_quest_items begin

--- a/scripts_src/headers/upu.h
+++ b/scripts_src/headers/upu.h
@@ -141,28 +141,26 @@ procedure cult_rep begin
    return rep;
 end
 // account for Evil_Critter, absolute "good" value. More is better.
-procedure self_rep begin
+procedure perceived_rep begin
    variable rep := beacon_rep;
-   if rep < 0 and self_is_evil then rep := abs(rep);
+   if self_is_evil then rep := -rep;
    if dude_has_cult then rep := abs(rep);
    return rep;
 end
-#define self_rep_positive (self_rep > 0)
-#define self_rep_negative (self_rep < 0)
+#define perceived_rep_positive (perceived_rep > 0)
+#define perceived_rep_negative (perceived_rep < 0)
 
 // normal mode: critter likes dude if he has title, taking Evil_Critter into account
 procedure check_title(variable title) begin
    variable rep := cult_rep;
-   if not self_is_evil and rep >= title then return true;
-   if self_is_evil and rep <= title then return true;
-   return false;
+   if self_is_evil then return (rep <= title);
+   else return (rep >= title);
 end
 // inverse mode: critter dislikes dude if he has title, taking Evil_Critter into account
 procedure check_title_bad(variable title) begin
    variable rep := cult_rep;
-   if not self_is_evil and rep <= title then return true;
-   if self_is_evil and rep >= title then return true;
-   return false;
+   if self_is_evil then return (rep >= title);
+   else return (rep <= title);
 end
 
 // call before restock

--- a/scripts_src/klamath/kcsulik.ssl
+++ b/scripts_src/klamath/kcsulik.ssl
@@ -342,7 +342,7 @@ procedure critter_p_proc begin
        attack(dude_obj);
    end
    else if (Sulik_In_Party) then begin
-      if self_rep < SULIK_BAD_KARMA then begin
+      if perceived_rep < SULIK_BAD_KARMA then begin
          call Node70a;
          ndebug("Evil Spirit");
       end
@@ -496,7 +496,7 @@ procedure talk_p_proc begin
    else if has_rep_slaver then begin
       call Node071;
    end
-   else if self_rep < SULIK_BAD_KARMA then begin
+   else if perceived_rep < SULIK_BAD_KARMA then begin
       call Node70a;
    end
    else if ((Sulik_In_Party) or (party_is_waiting)) then begin

--- a/scripts_src/main/ahhakun.ssl
+++ b/scripts_src/main/ahhakun.ssl
@@ -288,7 +288,7 @@ procedure talk_p_proc begin
        kill_critter(self_obj,ANIM_fall_front_sf);
    end
 
-   else if (self_rep_negative or (local_var(LVAR_reaction_level) <= REACTION_LEVEL_BAD)) then begin
+   else if (perceived_rep_negative or (local_var(LVAR_reaction_level) <= REACTION_LEVEL_BAD)) then begin
        start_gdialog(NAME,self_obj,4,HEAD_HAKUNIN,BACKGROUND_TENT);
        gSay_Start;
          //added by killap

--- a/scripts_src/modoc/mcbaltha.ssl
+++ b/scripts_src/modoc/mcbaltha.ssl
@@ -238,7 +238,7 @@ end
 procedure Node995 begin
    if (town_rep_is_accepted or perceived_rep >= KARMA_SHIELD_OF_HOPE) then begin
       call Node011;
-   end else if town_rep_is_antipaty or perceived_rep <= KARMA_SWORD_OF_DESPAIR) then begin
+   end else if (town_rep_is_antipaty or perceived_rep <= KARMA_SWORD_OF_DESPAIR) then begin
       call Node017;
    end else begin
       call Node018;

--- a/scripts_src/modoc/mcbaltha.ssl
+++ b/scripts_src/modoc/mcbaltha.ssl
@@ -236,9 +236,9 @@ procedure Node996 begin
    end
 end
 procedure Node995 begin
-   if (town_rep_is_accepted or check_title(KARMA_SHIELD_OF_HOPE)) then begin
+   if (town_rep_is_accepted or perceived_rep >= KARMA_SHIELD_OF_HOPE) then begin
       call Node011;
-   end else if town_rep_is_antipaty or check_title_bad(KARMA_SWORD_OF_DESPAIR) then begin
+   end else if town_rep_is_antipaty or perceived_rep <= KARMA_SWORD_OF_DESPAIR) then begin
       call Node017;
    end else begin
       call Node018;

--- a/scripts_src/navarro/ccxarn.ssl
+++ b/scripts_src/navarro/ccxarn.ssl
@@ -432,7 +432,7 @@ procedure Node004 begin
 end
 
 procedure Node005 begin
-   if not self_rep_negative then begin
+   if (perceived_rep >= 0) then begin
       call Node05a;
    end
    else begin
@@ -453,7 +453,7 @@ procedure Node05b begin
 end
 
 procedure Node05c begin
-   if not self_rep_negative then begin
+   if (perceived_rep >= 0) then begin
       Reply(122);
 
       NLowOption(124,Node006);

--- a/scripts_src/ncr/scmerk.ssl
+++ b/scripts_src/ncr/scmerk.ssl
@@ -597,7 +597,7 @@ nbody(002)
       msgNum := 105;
    else
       set_merk_status(MERK_STATUS_MET);
-   if (msgNum == 109 and check_title_bad(KARMA_DEFENDER)) then // was (check_general_rep < KARMA_DEFENDER)
+   if (msgNum == 109 and cult_rep < KARMA_DEFENDER) then
       msgNum := 105;
    if (msgNum == 113 and dude_is_male) then
       msgNum := 105;
@@ -611,7 +611,7 @@ nbody(003)
    msgNum += Random(0, 6);
    if (msgNum == 115 and not has_rep_childkiller) then
       msgNum := 114;
-   if (msgNum == 116 and check_title_bad(KARMA_DEFENDER)) then // was (check_general_rep < KARMA_DEFENDER)
+   if (msgNum == 116 and cult_rep < KARMA_DEFENDER) then
       msgNum := 114;
    if (msgNum == 117 and dude_is_male) then
       msgNum := 114;

--- a/scripts_src/ncr/scmerk.ssl
+++ b/scripts_src/ncr/scmerk.ssl
@@ -597,7 +597,7 @@ nbody(002)
       msgNum := 105;
    else
       set_merk_status(MERK_STATUS_MET);
-   if (msgNum == 109 and check_title_bad(KARMA_DEFENDER)) then
+   if (msgNum == 109 and check_title_bad(KARMA_DEFENDER)) then // was (check_general_rep < KARMA_DEFENDER)
       msgNum := 105;
    if (msgNum == 113 and dude_is_male) then
       msgNum := 105;
@@ -611,7 +611,7 @@ nbody(003)
    msgNum += Random(0, 6);
    if (msgNum == 115 and not has_rep_childkiller) then
       msgNum := 114;
-   if (msgNum == 116 and check_title_bad(KARMA_DEFENDER)) then
+   if (msgNum == 116 and check_title_bad(KARMA_DEFENDER)) then // was (check_general_rep < KARMA_DEFENDER)
       msgNum := 114;
    if (msgNum == 117 and dude_is_male) then
       msgNum := 114;

--- a/scripts_src/ncr/scvortis.ssl
+++ b/scripts_src/ncr/scvortis.ssl
@@ -565,7 +565,7 @@ procedure Node19a begin
    add_obj_to_inven(self_obj, obj);
    dude_caps_adjust(500);
 
-   if has_rep_slaver or (self_rep >= abs(KARMA_BETRAYER)) then
+   if has_rep_slaver or (perceived_rep >= abs(KARMA_BETRAYER)) then
       call Node024;
    else
       call Node019;

--- a/scripts_src/ncr/scvortis.ssl
+++ b/scripts_src/ncr/scvortis.ssl
@@ -565,7 +565,7 @@ procedure Node19a begin
    add_obj_to_inven(self_obj, obj);
    dude_caps_adjust(500);
 
-   if has_rep_slaver or (perceived_rep >= abs(KARMA_BETRAYER)) then
+   if has_rep_slaver or (beacon_rep <= KARMA_BETRAYER or dude_has_cult) then
       call Node024;
    else
       call Node019;

--- a/scripts_src/newreno/ncchrwri.ssl
+++ b/scripts_src/newreno/ncchrwri.ssl
@@ -205,7 +205,7 @@ end
 procedure Node999 begin
 end
 procedure Node990 begin
-   if has_rep_berserker or has_rep_childkiller or (self_rep < -100) then begin
+   if has_rep_berserker or has_rep_childkiller or (perceived_rep < -100) then begin
       call Node013;
    end else begin
       call Node012;

--- a/scripts_src/newreno/nccody.ssl
+++ b/scripts_src/newreno/nccody.ssl
@@ -218,7 +218,7 @@ procedure talk_p_proc begin
       start_dialog_at_node(Node016);
    end else if ((dude_wearing_power_armor) or (has_rep_slaver)) then begin
       start_dialog_at_node(Node012);
-   end else if (self_rep < -100) or has_rep_childkiller then begin
+   end else if (perceived_rep < -100) or has_rep_childkiller then begin
       start_dialog_at_node(Node013);
    end else if (marcus_is_dude_companion) then begin
       start_dialog_at_node(Node014);
@@ -328,7 +328,7 @@ end
 procedure Node003 begin
    if (Fallout2_enclave_destroyed) then begin
       Reply(220);
-      if (self_rep < -100) or has_rep_childkiller then begin
+      if (perceived_rep < -100) or has_rep_childkiller then begin
          BOption(223, Node990, -003);
          BOption(225, Node990, 004);
       end
@@ -507,7 +507,7 @@ procedure Node018 begin
    NOption(382, Node019, 004);
 end
 procedure Node019 begin
-   if (self_rep < 0) or has_rep_childkiller then begin
+   if perceived_rep_negative or has_rep_childkiller then begin
       Reply(391);
       BOption(393, Node003, -003);
       BOption(395, Node003, 004);

--- a/scripts_src/newreno/nckeiwri.ssl
+++ b/scripts_src/newreno/nckeiwri.ssl
@@ -215,7 +215,7 @@ end
 procedure Node999 begin
 end
 procedure Node990 begin
-   if has_rep_berserker or has_rep_childkiller or (self_rep < -100) then begin
+   if has_rep_berserker or has_rep_childkiller or (perceived_rep < -100) then begin
       call Node014;
    end else if (is_success(roll_vs_skill(dude_obj,SKILL_SPEECH,(-30 * has_rep_slaver)))) then begin
       call Node013;

--- a/scripts_src/rndenctr/eastereg.ssl
+++ b/scripts_src/rndenctr/eastereg.ssl
@@ -765,7 +765,7 @@ procedure Node025 begin
 end
 
 procedure Node025b begin
-   if self_rep_negative then
+   if (check_general_rep < 0 or dude_has_cult) then
       call Node026;
    else
       call Node027;

--- a/scripts_src/rndenctr/eastereg.ssl
+++ b/scripts_src/rndenctr/eastereg.ssl
@@ -642,7 +642,7 @@ procedure Node999 begin
 end
 
 procedure Node990 begin
-   if ( (check_general_rep > 1000) and (local_var(LVAR_GAVE_LIGHT_SABER) == 0) ) then
+   if ( (beacon_rep > 1000) and (local_var(LVAR_GAVE_LIGHT_SABER) == 0) ) then
       call Node009;
    else
       call Node010;
@@ -656,7 +656,7 @@ procedure Node991 begin
 end
 
 procedure Node992 begin
-   if ( (check_general_rep < -1000) and (local_var(LVAR_GAVE_LIGHT_SABER) == 0) ) then
+   if ( (beacon_rep < -1000) and (local_var(LVAR_GAVE_LIGHT_SABER) == 0) ) then
       call Node017;
    else
       call Node016;

--- a/scripts_src/rndenctr/eccvnmst.ssl
+++ b/scripts_src/rndenctr/eccvnmst.ssl
@@ -177,11 +177,11 @@ procedure talk_p_proc begin
 
    GetReaction;
 
-   if ((CITY_START >= 0) and self_rep_negative) then begin
+   if ((CITY_START >= 0) and perceived_rep_negative) then begin
        call Node014;
    end
 
-   else if ((CITY_START < 0) and self_rep_negative) then begin
+   else if ((CITY_START < 0) and perceived_rep_negative) then begin
        call Node015;
    end
 

--- a/scripts_src/sanfran/fckenlee.ssl
+++ b/scripts_src/sanfran/fckenlee.ssl
@@ -573,7 +573,7 @@ procedure Node004 begin
 end
 
 procedure Node89 begin
-   if ((neutral_critter_reaction or good_critter_reaction) and check_title(KARMA_BETRAYER)) then
+   if ((neutral_critter_reaction or good_critter_reaction) and perceived_rep >= KARMA_BETRAYER) then
       call Node008;
    else
       call Node009;

--- a/scripts_src/template/random_merchant.ssl
+++ b/scripts_src/template/random_merchant.ssl
@@ -140,18 +140,18 @@ procedure talk_p_proc begin
    else if (Personality < 0) then
        call Node015;
 
-   else if ((CITY_START >= 0) and self_rep_negative) then begin
+   else if ((CITY_START >= 0) and perceived_rep_negative) then begin
        call Node012;
    end
 
-   else if ((CITY_START <  0) and self_rep_negative) then begin
+   else if ((CITY_START <  0) and perceived_rep_negative) then begin
        call Node009;
    end
 
    else begin
        start_gdialog(NAME,self_obj,4,-1,-1);
        gSay_Start;
-           if ((CITY_START >= 0) and self_rep_positive) then
+           if ((CITY_START >= 0) and (perceived_rep >= 0)) then
                call Node010;
            else
                call Node011;

--- a/scripts_src/valtcity/vcamanda.ssl
+++ b/scripts_src/valtcity/vcamanda.ssl
@@ -200,7 +200,7 @@ procedure talk_p_proc begin
    if ( (global_var(GVAR_QUEST_JOSHUA) == JOSHUA_UNKNOWN) and (dude_iq < 4) ) then
       call Node005;
    else if( (global_var(GVAR_QUEST_JOSHUA) == JOSHUA_UNKNOWN) and
-      (self_rep_negative or has_rep_slaver or has_rep_childkiller or (local_var(LVAR_Amanda_Pissed) == 1) )) then
+            (perceived_rep_negative or has_rep_slaver or has_rep_childkiller or (local_var(LVAR_Amanda_Pissed) == 1) )) then
       call Node006;
    else if( global_var(GVAR_QUEST_JOSHUA) == JOSHUA_UNKNOWN ) then begin
        start_gdialog(NAME,self_obj,4,-1,-1);

--- a/scripts_src/valtcity/vccasidy.ssl
+++ b/scripts_src/valtcity/vccasidy.ssl
@@ -493,7 +493,7 @@ end
 
 procedure Node001a begin
    set_local_var( LVAR_Cassidy_Offered, 1 );
-   if ( (dude_charisma == 1) or has_rep_slaver or has_rep_childkiller or check_title_bad(-100) or dude_at_max_party_size ) then
+   if ( (dude_charisma == 1) or has_rep_slaver or has_rep_childkiller or (perceived_rep < -100) or dude_at_max_party_size ) then
       call Node015;
    else
       call Node016;
@@ -616,14 +616,14 @@ procedure Node015 begin
       Reply(157);
    else if( has_rep_slaver ) then
       Reply(158);
-   else if ( has_rep_childkiller or check_title_bad(-100) ) then
+   else if ( has_rep_childkiller or (perceived_rep < -100) ) then
       Reply(159);
    else
       Reply(160);
 
-   if (self_rep >= -100) and (not has_rep_slaver) and (not has_rep_childkiller) and (dude_charisma > 1) then
+   if (perceived_rep >= -100) and (not has_rep_slaver) and (not has_rep_childkiller) and (dude_charisma > 1) then
       NOption(161, Node999, 004);
-   if (self_rep < -100) or has_rep_slaver or has_rep_childkiller or (dude_charisma == 1)  then begin
+   if (perceived_rep < -100) or has_rep_slaver or has_rep_childkiller or (dude_charisma == 1) then begin
       BOption(162, Node999, 004);
       NOption(163, Node999, 004);
    end
@@ -753,7 +753,7 @@ procedure Node1100 begin
       Reply(2100);
       BOption(3100, Node999, 001); //added by killap
       NOption(3200, Node999, 001); //added by killap
-   end else if (has_rep_childkiller or check_title_bad(-100)) then begin
+   end else if( has_rep_childkiller or (perceived_rep < -100) ) then begin
       set_self_abandon_party; //added by killap
       Reply(2200);
       BOption(3100, Node999, 001); //added by killap

--- a/scripts_src/vault13/ocgoris.ssl
+++ b/scripts_src/vault13/ocgoris.ssl
@@ -284,7 +284,7 @@ procedure critter_p_proc begin
       if (Goris_In_Party and self_visible) then begin
          party_member_follow_dude
 
-         if has_rep_berserker or has_rep_childkiller or self_rep_negative then begin
+         if has_rep_berserker or has_rep_childkiller or perceived_rep_negative then begin
             float_msg(self_obj, mstr(1160), FLOAT_MSG_RED);
             set_self_abandon_party;
             set_self_team(TEAM_VAULT13);
@@ -732,7 +732,7 @@ procedure Node013 begin
 end
 
 procedure Node014 begin
-   if not (self_rep_negative or town_rep_negative or has_rep_childkiller or has_rep_berserker) then begin
+   if not (perceived_rep_negative or town_rep_negative or has_rep_childkiller or has_rep_berserker) then begin
       ndebug("true_party_size " + true_party_size);
       ndebug("party_max_formula " + party_max_formula);
       ndebug("((true_party_size >= (party_max_formula)) or (true_party_size >= 5)): " + ((true_party_size >= (party_max_formula)) or (true_party_size >= 5)));

--- a/scripts_src/vault13/ocgrutha.ssl
+++ b/scripts_src/vault13/ocgrutha.ssl
@@ -130,7 +130,7 @@ import variable i_matt_obj;
 import variable i_gruthar_obj;
 
 #define GRUTHAR_NO_LIKE_YOU    \
-   (bad_critter_reaction or self_rep_negative or town_rep_negative or has_rep_childkiller or has_rep_berserker)
+   (bad_critter_reaction or perceived_rep_negative or town_rep_negative or has_rep_childkiller or has_rep_berserker)
 
 #define STARTTILE 14695
 


### PR DESCRIPTION
As discussed on the discord. I also simplify `check_title` and `check_title_bad` procedures.
Notes to some of the changes:
* hcmarcus.ssl: in line 637 originally it's `(check_general_rep >= 0)` but `preceived_rep_positive` uses `>` instead, so I don't use the marco.
* dcslvgrt.ssl: originally it was `(check_general_rep >= 0)`, judging by msg 215 (likes evil player) / 216 (doubt good player) it should use `cult_rep` instead of `perceived_rep`. Or maybe change the condition to `(perceived_rep <= 0)`?
* ccxarn.ssl: originally it was `(check_general_rep >= 0)` so I followed the same suit instead of "not negative".
* eastereg.ssl: reverted to the old conditions because the script is shared by many in the encounter and there's no evil critter definition.
* random_merchant.ssl: same as hcmarcus.ssl, from vanilla `ecmst*` it was `(check_general_rep >= 0)`.
* vccasidy.ssl: originally it was `(check_general_rep < -100)` but `check_title_bad` uses `<=` so I unified them with other `perceived_rep` usages.
* scmerk.ssl: I think `check_title_bad` shouldn't be used here, because he's an evil critter, the procedure basically returns the result of `(cult_rep > 250)` which seems wrong given by msg text. Probably should be just `cult_rep < KARMA_DEFENDER`.