### PR TITLE
Replace restock_fix macro with sfall's unsigned integer comparison

### DIFF
--- a/scripts_src/abbey/abbilbox.ssl
+++ b/scripts_src/abbey/abbilbox.ssl
@@ -22,6 +22,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "abbilbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_ABBILBOX
 
@@ -79,12 +80,8 @@ procedure map_enter_p_proc begin
        set_local_var(LVAR_Trapped,TRAPPED_STATUS);
    end
 
-   if (((game_time) < 0) and (local_var(LVAR_Restock_Time_Fix) == 0)) then begin
-      set_local_var(LVAR_Restock_Time, game_time - 1);
-      set_local_var(LVAR_Restock_Time_Fix, 1);
-   end
-
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
+      variable tmp_box := move_quest_items();
       check_restock_item(PID_BOTTLE_CAPS, 150, 225, 100)
       check_restock_item(PID_LEATHER_ARMOR, 1, 1, 100)
       check_restock_item(PID_HEALING_POWDER, 2, 4, 100)
@@ -102,6 +99,7 @@ procedure map_enter_p_proc begin
       check_restock_item(PID_FIRST_AID_KIT, 0, 1, 100)
       check_restock_item(PID_SPEAR, 1, 1, 100)
       check_restock_item(PID_FLARE, 1, 3, 100)
+      call restore_critical_items(tmp_box);
       set_local_var(LVAR_Restock_Time, (10 * ONE_GAME_DAY) + game_time);
    end
 

--- a/scripts_src/brokhill/hidocbox.ssl
+++ b/scripts_src/brokhill/hidocbox.ssl
@@ -23,6 +23,7 @@
 #define SCRIPT_REALNAME "hidocbox"
 #include "../headers/define.h"
 #include "../headers/broken1.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_HIDOCBOX
 
@@ -53,8 +54,7 @@ procedure map_enter_p_proc begin
 
    broken_hills_doc_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 200, 750, 100)
          check_restock_item(PID_FIRST_AID_KIT, 0, 1, 25)

--- a/scripts_src/brokhill/hijacbox.ssl
+++ b/scripts_src/brokhill/hijacbox.ssl
@@ -23,6 +23,7 @@
 #define SCRIPT_REALNAME "hijacbox"
 #include "../headers/define.h"
 #include "../headers/broken1.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_HIJACBOX
 
@@ -46,8 +47,7 @@ end
 procedure map_enter_p_proc begin
    broken_hills_jacob_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 200, 1250, 100)
          check_restock_item(PID_BUFFOUT, 0, 3, 25)

--- a/scripts_src/brokhill/hilbox.ssl
+++ b/scripts_src/brokhill/hilbox.ssl
@@ -23,6 +23,7 @@
 #define SCRIPT_REALNAME "hilbox"
 #include "../headers/define.h"
 #include "../headers/broken1.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_HILBOX
 
@@ -48,8 +49,7 @@ procedure map_enter_p_proc begin
    broken_hills_liz_box := self_obj;
    if (is_loading_game == false) then begin
       if (map_var(MVAR_Liz_Dead) == 0) then begin
-         restock_fix
-         if (local_var(LVAR_Restock_Time) < game_time) then begin
+         if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
             variable tmp_box := move_quest_items();
             check_restock_item(PID_BOTTLE_CAPS, 100, 300, 100)
             check_restock_item(PID_ROPE, 1, 5, 100)

--- a/scripts_src/brokhill/hioutbox.ssl
+++ b/scripts_src/brokhill/hioutbox.ssl
@@ -23,6 +23,7 @@
 #define SCRIPT_REALNAME "hioutbox"
 #include "../headers/define.h"
 #include "../headers/broken1.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_HIOUTBOX
 
@@ -46,8 +47,7 @@ end
 procedure map_enter_p_proc begin
    broken_hills_outfitter_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 100, 500, 100)
          check_restock_item(PID_223_FMJ, 0, 3, 25)

--- a/scripts_src/den/dcdealer.ssl
+++ b/scripts_src/den/dcdealer.ssl
@@ -3,6 +3,7 @@
 #include "../headers/define.h"
 #include "../headers/den.h"
 #include "../headers/denres1.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_DCDEALER
 
@@ -147,8 +148,7 @@ procedure map_enter_p_proc begin
       dealer := 1;
 
    if (dealer and is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          check_restock_item(PID_JET, 2, 5, 100)
          check_restock_item(PID_BUFFOUT, 0, 1, 100)
          check_restock_item(PID_STIMPAK, 2, 3, 100)

--- a/scripts_src/den/diflibox.ssl
+++ b/scripts_src/den/diflibox.ssl
@@ -1,5 +1,5 @@
 /*
-   Copyright 1998-2003 Interplay Entertainment Corp.  All rights reserved.
+	Copyright 1998-2003 Interplay Entertainment Corp.  All rights reserved.
 */
 
 /*
@@ -18,6 +18,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "diflibox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_DIFLIBOX
 
@@ -40,8 +41,7 @@ procedure map_enter_p_proc begin
 /* Set up the door state when the player first enters the map */
    den_flick_box_obj := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          self_caps_adjust(random(55, 61) - self_caps);
          check_restock_item(PID_JET, 0, 1, 100)

--- a/scripts_src/den/diflkbox.ssl
+++ b/scripts_src/den/diflkbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "diflkbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_DIFLKBOX
 
@@ -62,8 +63,7 @@ procedure map_enter_p_proc begin
        set_local_var(LVAR_Trapped,TRAPPED_STATUS);
    end
 
-   restock_fix
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       variable tmp_box := move_quest_items();
       check_restock_item(PID_BOTTLE_CAPS, 148, 3512, 100)
       check_restock_item(PID_LEATHER_ARMOR, 1, 1, 80)

--- a/scripts_src/den/dimetbox.ssl
+++ b/scripts_src/den/dimetbox.ssl
@@ -18,6 +18,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "dimetbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_DIMETBOX
 
@@ -46,8 +47,7 @@ procedure map_enter_p_proc begin
    /* Set up the door state when the player first enters the map */
    den_metzger_box_obj := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          if (gave_metzger_party_stuff) then begin
             off_gave_metzger_party_stuff;
             the_box_to_kill := create_object(PID_FOOTLOCKER_CLEAN_RIGHT, 0, 0);

--- a/scripts_src/den/dimombox.ssl
+++ b/scripts_src/den/dimombox.ssl
@@ -18,6 +18,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "dimombox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_DIMOMBOX
 
@@ -39,8 +40,7 @@ procedure map_enter_p_proc begin
    /* Set up the door state when the player first enters the map */
    den_mom_box_obj := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          self_caps_adjust(random(110, 125) - self_caps);
          check_restock_item(PID_STIMPAK, 0, 2, 90)

--- a/scripts_src/den/dismibox.ssl
+++ b/scripts_src/den/dismibox.ssl
@@ -18,6 +18,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "dismibox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_DISMIBOX
 
@@ -38,8 +39,7 @@ procedure map_enter_p_proc begin
    /* Set up the door state when the player first enters the map */
    den_smitty_box_obj := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOX_OF_NOODLES, 0, 1, 100)
          check_restock_item(PID_BEER, 0, 6, 100)

--- a/scripts_src/den/ditubbox.ssl
+++ b/scripts_src/den/ditubbox.ssl
@@ -18,6 +18,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "ditubbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_DITUBBOX
 
@@ -39,8 +40,7 @@ procedure map_enter_p_proc begin
    /* Set up the door state when the player first enters the map */
    den_tubby_box_obj := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          self_caps_adjust(random(151, 161) - self_caps);
          check_restock_item(PID_JET, 5, 10, 100)

--- a/scripts_src/gecko/giperbox.ssl
+++ b/scripts_src/gecko/giperbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "giperbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_GIPERBOX
 
@@ -44,8 +45,7 @@ end
 procedure map_enter_p_proc begin
    gecko_percy_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 500, 1000, 100)
          check_restock_item(PID_RAD_X, 0, 1, 100)

--- a/scripts_src/generic/zinuke.ssl
+++ b/scripts_src/generic/zinuke.ssl
@@ -20,6 +20,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "zinuke"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_ZINUKE
 #define CUR_COMP_SCRIPT         SCRIPT_ZINUKE
@@ -218,8 +219,7 @@ end
 ***************************************************************************************/
 
 procedure map_enter_p_proc begin
-   restock_fix
-   if (game_time > local_var(LVAR_Restock_Time)) then begin
+   if (unsigned_int_compare(game_time, local_var(LVAR_Restock_Time)) > 0) then begin
       if (local_var(LVAR_Stock) < MAX_STOCK) then
          set_local_var(LVAR_Stock, Random(MAX_STOCK / 2, MAX_STOCK));
 

--- a/scripts_src/klamath/kibbox.ssl
+++ b/scripts_src/klamath/kibbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "kibbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 #define NAME                    SCRIPT_KIBBOX
 #include "../headers/command.h"
 
@@ -59,8 +60,7 @@ procedure map_enter_p_proc begin
        set_local_var(LVAR_Trapped,TRAPPED_STATUS);
    end
 
-   restock_fix
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       variable tmp_box := move_quest_items();
       check_restock_item(PID_BOTTLE_CAPS, 150, 225, 100)
       check_restock_item(PID_LEATHER_ARMOR, 1, 1, 100)

--- a/scripts_src/klamath/kidbox.ssl
+++ b/scripts_src/klamath/kidbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "kidbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 #define NAME                    SCRIPT_KIDBOX
 #include "../headers/command.h"
 /* Defines and Macros */
@@ -61,8 +62,7 @@ procedure map_enter_p_proc begin
        set_local_var(LVAR_Trapped,TRAPPED_STATUS);
    end
 
-   restock_fix
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       variable tmp_box := move_quest_items();
       check_restock_item(PID_BOTTLE_CAPS, 65, 65, 100)
       check_restock_item(PID_MEAT_JERKY, 45, 45, 100)

--- a/scripts_src/klamath/kisbox.ssl
+++ b/scripts_src/klamath/kisbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "kisbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 #define NAME                    SCRIPT_KISBOX
 #include "../headers/command.h"
 
@@ -60,8 +61,7 @@ procedure map_enter_p_proc begin
        set_local_var(LVAR_Trapped,TRAPPED_STATUS);
    end
 
-   restock_fix
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       variable tmp_box := move_quest_items();
       check_restock_item(PID_BOTTLE_CAPS, 125, 250, 100)
       check_restock_item(PID_LEATHER_JACKET, 1, 1, 100)

--- a/scripts_src/maps/tribem1.ssl
+++ b/scripts_src/maps/tribem1.ssl
@@ -6,6 +6,7 @@
 #include "../headers/define.h"
 #include "../headers/updatmap.h"
 #include "../headers/tribe01.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_TRIBEM1          //Script name from scripts.h
 
@@ -22,12 +23,10 @@ export variable GHOST_obj := 0;
 export variable WARRIOR_obj;
 export variable SULIK_SIS_obj;
 
-procedure start
-begin
+procedure start begin
 end
 
-procedure map_exit_p_proc
-begin
+procedure map_exit_p_proc begin
    if (global_var(GVAR_SULIK_SISTER) == 4) then begin
       set_global_var(GVAR_SULIK_SISTER,5);
    end
@@ -39,15 +38,13 @@ begin
    end
 end
 
-procedure map_enter_p_proc
-begin
+procedure map_enter_p_proc begin
    variable Critter;
 
    if (dude_elevation == 0) then begin
-      restock_fix_map
-      if (map_var(MVAR_Restock_Time) < game_time) then begin
-          set_map_var(MVAR_Restock_Time, (random(6,8) * ONE_GAME_DAY) + game_time);
-          call Make_Plants;
+      if (unsigned_int_compare(map_var(MVAR_Restock_Time), game_time) < 0) then begin
+         set_map_var(MVAR_Restock_Time, (random(6,8) * ONE_GAME_DAY) + game_time);
+         call Make_Plants;
       end
    end
 
@@ -67,7 +64,7 @@ begin
    end
 
    if (map_first_run) then begin
-         display_msg(mstr(100));
+      display_msg(mstr(100));
    end
 
 
@@ -137,23 +134,22 @@ begin
 end
 
 
-procedure map_update_p_proc
-begin
-  Lighting;
+procedure map_update_p_proc begin
+   Lighting;
 end
 
 procedure Make_Plants begin
-  variable plant;
-  if (not(tile_contains_obj_pid(16081,0,PID_XANDER_ROOT))) then begin
-    plant:=create_object(PID_XANDER_ROOT,16081,0);
-  end
-  if (not(tile_contains_obj_pid(21251,0,PID_XANDER_ROOT))) then begin
-    plant:=create_object(PID_XANDER_ROOT,21251,0);
-  end
-  if (not(tile_contains_obj_pid(16850,0,PID_BROC_FLOWER))) then begin
-    plant:=create_object(PID_BROC_FLOWER,16850,0);
-  end
-  if (not(tile_contains_obj_pid(21134,0,PID_BROC_FLOWER))) then begin
-    plant:=create_object(PID_BROC_FLOWER,21134,0);
-  end
+   variable plant;
+   if (not(tile_contains_obj_pid(16081,0,PID_XANDER_ROOT))) then begin
+      plant:=create_object(PID_XANDER_ROOT,16081,0);
+   end
+   if (not(tile_contains_obj_pid(21251,0,PID_XANDER_ROOT))) then begin
+      plant:=create_object(PID_XANDER_ROOT,21251,0);
+   end
+   if (not(tile_contains_obj_pid(16850,0,PID_BROC_FLOWER))) then begin
+      plant:=create_object(PID_BROC_FLOWER,16850,0);
+   end
+   if (not(tile_contains_obj_pid(21134,0,PID_BROC_FLOWER))) then begin
+      plant:=create_object(PID_BROC_FLOWER,21134,0);
+   end
 end

--- a/scripts_src/maps/tribem2.ssl
+++ b/scripts_src/maps/tribem2.ssl
@@ -6,6 +6,7 @@
 #include "../headers/define.h"
 #include "../headers/updatmap.h"
 #include "../headers/tribe02.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_TRIBEM2          //Script name from scripts.h
 
@@ -20,34 +21,29 @@ procedure Make_Fish;
 export variable WARRIOR_obj := 0;
 export variable GECKO_obj := 0;
 
-procedure start
-begin
+procedure start begin
 end
 
-procedure map_exit_p_proc
-begin
+procedure map_exit_p_proc begin
 end
 
-procedure map_enter_p_proc
-begin
+procedure map_enter_p_proc begin
    variable Critter;
 
    if (map_first_run) then begin
-         display_msg(mstr(100));
+      display_msg(mstr(100));
 
-         Critter:=create_object_sid(PID_TOUGH_GOLDEN_GECKO,13295,1,SCRIPT_TRIBEC10);
+      Critter:=create_object_sid(PID_TOUGH_GOLDEN_GECKO,13295,1,SCRIPT_TRIBEC10);
 
-         Critter:=create_object_sid(PID_MALE_PRIMITIVE_HUNTER,13493,1,SCRIPT_TRIBEC9);
+      Critter:=create_object_sid(PID_MALE_PRIMITIVE_HUNTER,13493,1,SCRIPT_TRIBEC9);
    end
 
-   restock_fix_map
-
-   if (map_var(MVAR_Restock_Time) < game_time) then begin
-       set_map_var(MVAR_Restock_Time, (random(6,8) * ONE_GAME_DAY) + game_time);
-       call Make_Fish;
+   if (unsigned_int_compare(map_var(MVAR_Restock_Time), game_time) < 0) then begin
+      set_map_var(MVAR_Restock_Time, (random(6,8) * ONE_GAME_DAY) + game_time);
+      call Make_Fish;
    end
 
-   if( dude_elevation == 0) then
+   if (dude_elevation == 0) then
       Lighting;
    else
       Cavern_Lighting;
@@ -55,10 +51,9 @@ begin
 end
 
 
-procedure map_update_p_proc
-begin
+procedure map_update_p_proc begin
 
-   if( dude_elevation == 0) then
+   if (dude_elevation == 0) then
       Lighting;
    else
       Cavern_Lighting;
@@ -66,20 +61,20 @@ begin
 end
 
 procedure Make_Fish begin
-  variable fish;
-  if (not(tile_contains_obj_pid(19695,0,PID_FISH2))) then begin
-    fish:=create_object(PID_FISH2,19695,0);
-  end
-  if (not(tile_contains_obj_pid(19495,0,PID_FISH2))) then begin
-    fish:=create_object(PID_FISH2,19495,0);
-  end
-  if (not(tile_contains_obj_pid(19492,0,PID_FISH))) then begin
-    fish:=create_object(PID_FISH,19492,0);
-  end
-  if (not(tile_contains_obj_pid(21721,0,PID_FISH2))) then begin
-    fish:=create_object(PID_FISH2,21721,0);
-  end
-  if (not(tile_contains_obj_pid(21519,0,PID_FISH2))) then begin
-    fish:=create_object(PID_FISH2,21519,0);
-  end
+   variable fish;
+   if (not(tile_contains_obj_pid(19695,0,PID_FISH2))) then begin
+      fish:=create_object(PID_FISH2,19695,0);
+   end
+   if (not(tile_contains_obj_pid(19495,0,PID_FISH2))) then begin
+      fish:=create_object(PID_FISH2,19495,0);
+   end
+   if (not(tile_contains_obj_pid(19492,0,PID_FISH))) then begin
+      fish:=create_object(PID_FISH,19492,0);
+   end
+   if (not(tile_contains_obj_pid(21721,0,PID_FISH2))) then begin
+      fish:=create_object(PID_FISH2,21721,0);
+   end
+   if (not(tile_contains_obj_pid(21519,0,PID_FISH2))) then begin
+      fish:=create_object(PID_FISH2,21519,0);
+   end
 end

--- a/scripts_src/modoc/mibalbox.ssl
+++ b/scripts_src/modoc/mibalbox.ssl
@@ -20,6 +20,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "mibalbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 #define NAME                    SCRIPT_MIBALBOX
 #include "../headers/command.h"
 
@@ -45,8 +46,7 @@ procedure map_enter_p_proc begin
    modoc_balthas_box_obj := self_obj;
    if (is_loading_game == false) then begin
 
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 475, 525, 100)
          check_restock_item(PID_LEATHER_ARMOR, 1, 1, 100)

--- a/scripts_src/modoc/migribox.ssl
+++ b/scripts_src/modoc/migribox.ssl
@@ -20,6 +20,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "migribox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 #define NAME                    SCRIPT_MIGRIBOX
 #include "../headers/command.h"
 
@@ -43,8 +44,7 @@ end
 procedure map_enter_p_proc begin
    modoc_grisham_box_obj := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 95, 105, 100)
          check_restock_item(PID_MEAT_JERKY, 15, 20, 100)

--- a/scripts_src/modoc/mijobox.ssl
+++ b/scripts_src/modoc/mijobox.ssl
@@ -17,11 +17,7 @@
 #define map_enter_action                     match_dude_elevation;                                          \
                                              if (is_loading_game == false) then begin                       \
                                                 if (not(jo_dead)) then begin                                \
-                                                   if (((game_time) < 0) and (local_var(LVAR_Restock_Time_Fix) == 0)) then begin \
-                                                      set_local_var(LVAR_Restock_Time, game_time - 1); \
-                                                      set_local_var(LVAR_Restock_Time_Fix, 1); \
-                                                   end \
-                                                   if (local_var(LVAR_Restock_Time) < game_time) then begin    \
+                                                   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin \
                                                       destroy_obj_inven(self_obj);                             \
                                                       check_restock_item(PID_ROPE, 1, 2, 100)                  \
                                                       check_restock_item(PID_10MM_JHP, 1, 2, 100)              \
@@ -44,4 +40,5 @@
                                              end
 
 #include "../headers/modmain.h"
+#include "../sfall/lib.math.h"
 #include "../generic/zilocker.ssl"

--- a/scripts_src/ncr/scduppo.ssl
+++ b/scripts_src/ncr/scduppo.ssl
@@ -28,6 +28,7 @@
 #define SCRIPT_REALNAME "scduppo"
 #include "../headers/define.h"
 #include "../headers/ncr1.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_SCDUPPO
 #define TOWN_REP_VAR         GVAR_TOWN_REP_NCR
@@ -133,8 +134,7 @@ procedure map_enter_p_proc begin
    set_self_team(TEAM_NCR);
    set_self_ai(AI_STORE_OWNER);
 
-   restock_fix
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       check_restock_item(PID_BOTTLE_CAPS, 30, 30, 100)
       set_local_var(LVAR_Restock_Time, (random(1,6) * ONE_GAME_DAY) + game_time);
    end

--- a/scripts_src/ncr/scdusty.ssl
+++ b/scripts_src/ncr/scdusty.ssl
@@ -28,6 +28,7 @@
 #define SCRIPT_REALNAME "scdusty"
 #include "../headers/define.h"
 #include "../headers/ncr1.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_SCDUSTY
 #define TOWN_REP_VAR         GVAR_TOWN_REP_NCR
@@ -100,8 +101,7 @@ procedure map_enter_p_proc begin
    set_self_team(TEAM_NCR);
    set_self_ai(AI_TOUGH_CITIZEN);
 
-   restock_fix
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       ndebug("Should have restocked");
       variable tmp_box := move_quest_items();
       check_restock_item(PID_BOOZE, 10, 20, 100)

--- a/scripts_src/ncr/scmikey.ssl
+++ b/scripts_src/ncr/scmikey.ssl
@@ -28,6 +28,7 @@
 #define SCRIPT_REALNAME "scmikey"
 #include "../headers/define.h"
 #include "../headers/ncrent.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_SCMIKEY
 #define TOWN_REP_VAR         GVAR_TOWN_REP_NCR
@@ -103,7 +104,7 @@ procedure map_enter_p_proc begin
    set_self_team(TEAM_NCR_ENTRANCE);
    set_self_ai(AI_STORE_OWNER);
    // comment out by killap
-   //if (local_var(LVAR_Restock_Time) < game_time) then begin
+   //if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
    //   check_restock_item(PID_BOTTLE_CAPS, 50, 100, 100)
    //   check_restock_item(PID_MEAT_ON_A_STICK, 25, 30, 100)
    //   set_local_var(LVAR_Restock_Time, (random(6,12) * ONE_GAME_DAY) + game_time);

--- a/scripts_src/ncr/sidtbl.ssl
+++ b/scripts_src/ncr/sidtbl.ssl
@@ -23,6 +23,7 @@
 
 #include "../headers/ncr1.h"
 #include "../headers/ncr.h"
+#include "../sfall/lib.math.h"
 
 /* Sets whether the door is locked or trapped */
 #define LOCKED_STATUS                   STATE_INACTIVE
@@ -152,8 +153,7 @@ procedure map_enter_p_proc begin
    ndebug("I_duppo_obj " + i_duppo_obj);
    if (i_duppo_obj != -1) then begin
 
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
 
 //Tools & ammo
          if (self_tile == DUPPO_TBL_1) then begin

--- a/scripts_src/ncr/simbox.ssl
+++ b/scripts_src/ncr/simbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "simbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_SIMBOX
 
@@ -65,8 +66,7 @@ procedure map_enter_p_proc begin
        obj_lock(self_obj);
    end
 
-   restock_fix
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       variable tmp_box := move_quest_items();
       check_restock_item(PID_IGUANA_ON_A_STICK, 10, 100, 100)
       check_restock_item(PID_MEAT_ON_A_STICK, 25, 30, 100) //moved here from scmikey

--- a/scripts_src/ncr/sishelf1.ssl
+++ b/scripts_src/ncr/sishelf1.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "sishelf1"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_SISHELF1
 
@@ -193,8 +194,7 @@ end
 procedure map_enter_p_proc begin
    if (buster_obj != -1 and buster_obj) then begin
 
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          ndebug("first restock shelf 1");
          variable tmp_box := move_quest_items();
          check_restock_item(PID_44_MAGNUM_JHP, 7, 10, 40)

--- a/scripts_src/ncr/sishelf2.ssl
+++ b/scripts_src/ncr/sishelf2.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "sishelf2"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_SISHELF2
 
@@ -194,8 +195,7 @@ end
 
 procedure map_enter_p_proc begin
    if (buster_obj != -1 and buster_obj) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          //Common
          check_restock_item(PID_KNIFE, 1, 5, 100)

--- a/scripts_src/ncr/sishelf3.ssl
+++ b/scripts_src/ncr/sishelf3.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "sishelf3"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_SISHELF3
 
@@ -192,8 +193,7 @@ end
 
 procedure map_enter_p_proc begin
    if (buster_obj and buster_obj != -1) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_LEATHER_JACKET, 1, 3, 100)
          check_restock_item(PID_LEATHER_ARMOR, 1, 3, 100)

--- a/scripts_src/newreno/nctray.ssl
+++ b/scripts_src/newreno/nctray.ssl
@@ -17,6 +17,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nctray"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 #define NAME                    SCRIPT_NCTRAY
 #define TOWN_REP_VAR            GVAR_TOWN_REP_NEW_RENO
 #include "../headers/command.h"
@@ -103,7 +104,7 @@ procedure Node058;
 
 #define LVAR_Flags                     (4)
 #define LVAR_Sex_T_Ray                 (5)
-#define LVAR_Restock_Time              (6)  // Seraph's Code - expansion
+#define LVAR_Restock_Time              (6) // Seraph's Code
 #define LVAR_Restock_Time_Fix          (7) // added by killap - expansion
 
 #define gave_car_exp_bit               bit_10
@@ -240,13 +241,12 @@ procedure map_enter_p_proc begin
       end
       nr_add_timer_event_rand(self_obj, 25, 35, float_param);
    end
-      restock_fix
-// Begin Seraph's Code - expansion
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
-         check_restock_item(PID_SMALL_ENERGY_CELL, 2, 6, 80)
-         check_restock_item(PID_MICRO_FUSION_CELL, 1, 3, 60)
-         set_local_var(LVAR_Restock_Time, game_time + (ONE_GAME_WEEK * Random(1, 2)));
-      end
+// Begin Seraph's Code
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
+      check_restock_item(PID_SMALL_ENERGY_CELL, 2, 6, 80)
+      check_restock_item(PID_MICRO_FUSION_CELL, 1, 3, 60)
+      set_local_var(LVAR_Restock_Time, game_time + (ONE_GAME_WEEK * Random(1, 2)));
+   end
 // End Seraph's Code
 end
 procedure map_exit_p_proc begin

--- a/scripts_src/newreno/nibisbox.ssl
+++ b/scripts_src/newreno/nibisbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nibisbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_NIBISBOX
 
@@ -45,8 +46,7 @@ end
 procedure map_enter_p_proc begin
    new_reno_bishop_bar_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_MUTATED_FRUIT, 1, 2, 100)
          check_restock_item(PID_JET, 2, 10, 100)

--- a/scripts_src/newreno/nieldbox.ssl
+++ b/scripts_src/newreno/nieldbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nieldbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_NIELDBOX
 
@@ -45,8 +46,7 @@ end
 procedure map_enter_p_proc begin
    new_reno_eldridge_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_SPRINGER_RIFLE, 1, 2, 100)
          check_restock_item(PID_44_MAGNUM_REVOLVER, 1, 1, 100)

--- a/scripts_src/newreno/nieldbx2.ssl
+++ b/scripts_src/newreno/nieldbx2.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nieldbx2"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_NIELDBOX
 
@@ -45,9 +46,8 @@ end
 procedure map_enter_p_proc begin
    new_reno_eldridge_box_2 := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
-         variable tmp_box = move_quest_items();
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
+         variable tmp_box := move_quest_items();
          check_restock_item(PID_ASSAULT_RIFLE, 1, 1, 25)
          check_restock_item(PID_COMBAT_SHOTGUN, 1, 1, 25)
          check_restock_item(PID_ROCKET_LAUNCHER, 1, 1, 25)

--- a/scripts_src/newreno/niethbox.ssl
+++ b/scripts_src/newreno/niethbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "niethbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_NIETHBOX
 
@@ -45,8 +46,7 @@ end
 procedure map_enter_p_proc begin
    new_reno_ethyl_wright_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          self_caps_adjust(random(1,12) - self_caps);
          check_restock_item(PID_NUKA_COLA, 1, 1, 100)

--- a/scripts_src/newreno/nijulbox.ssl
+++ b/scripts_src/newreno/nijulbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nijulbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_NIJULBOX
 
@@ -45,8 +46,7 @@ end
 procedure map_enter_p_proc begin
    new_reno_jules_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_JET, 1, 7, 100)
          check_restock_item(PID_STIMPAK, 1, 5, 100)

--- a/scripts_src/newreno/nimorbox.ssl
+++ b/scripts_src/newreno/nimorbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nimorbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_NIMORBOX
 
@@ -45,8 +46,7 @@ end
 procedure map_enter_p_proc begin
    new_reno_mordino_bar_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_MUTATED_FRUIT, 1, 2, 100)
          check_restock_item(PID_JET, 10, 20, 100)

--- a/scripts_src/newreno/nirenbox.ssl
+++ b/scripts_src/newreno/nirenbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nirenbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_NIRENBOX
 
@@ -45,8 +46,7 @@ end
 procedure map_enter_p_proc begin
    new_reno_renesco_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          self_caps_adjust(random(250,500) - self_caps);
          check_restock_item(PID_JET, 5, 10, 100)

--- a/scripts_src/newreno/nisalbox.ssl
+++ b/scripts_src/newreno/nisalbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nisalbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_NISALBOX
 
@@ -45,8 +46,7 @@ end
 procedure map_enter_p_proc begin
    new_reno_salvatore_bar_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_MUTATED_FRUIT, 1, 2, 100)
          check_restock_item(PID_JET, 2, 10, 100)

--- a/scripts_src/newreno/nitrybox.ssl
+++ b/scripts_src/newreno/nitrybox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nitrybox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_NITRYBOX
 
@@ -46,8 +47,7 @@ end
 procedure map_enter_p_proc begin
    new_reno_t_ray_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_SMALL_ENERGY_CELL, 2, 2, 100)
          check_restock_item(PID_MICRO_FUSION_CELL, 2, 2, 100)

--- a/scripts_src/newreno/nitulbox.ssl
+++ b/scripts_src/newreno/nitulbox.ssl
@@ -17,6 +17,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "nitulbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 #define NAME                    SCRIPT_NITULBOX
 #define TOWN_REP_VAR            GVAR_TOWN_REP_NEW_RENO
 #include "../headers/command.h"
@@ -60,8 +61,7 @@ procedure map_enter_p_proc begin
    if (is_loading_game == false) then begin
       if (tully_dead == false) then begin
 
-         restock_fix
-         if (local_var(LVAR_Restock_Time) < game_time) then begin
+         if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
             self_caps_adjust(random(1,50) - self_caps);
             set_local_var(LVAR_Poor_Box_Caps, self_caps);
             set_local_var(LVAR_Restock_Time, (7 * ONE_GAME_DAY) + game_time);

--- a/scripts_src/redding/rcdrjohn.ssl
+++ b/scripts_src/redding/rcdrjohn.ssl
@@ -28,6 +28,7 @@
 #define SCRIPT_REALNAME "rcdrjohn"
 #include "../headers/define.h"
 #include "../headers/reddown.h" // seraph's code
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_RCDRJOHN
 #define TOWN_REP_VAR            (GVAR_TOWN_REP_REDDING)
@@ -177,10 +178,7 @@ procedure map_enter_p_proc begin
    Doc_Johnson_Ptr:=self_obj;
 
    //added by killap - expansion
-
-   restock_fix
-
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       ndebug("Should have restocked");
       check_restock_item(PID_STIMPAK, 4, 5, 100)
       check_restock_item(PID_ANTIDOTE, 1, 1, 80)

--- a/scripts_src/redding/ricshbox.ssl
+++ b/scripts_src/redding/ricshbox.ssl
@@ -28,6 +28,7 @@
 #define SCRIPT_REALNAME "ricshbox"
 #include "../headers/define.h"
 //#include "../headers/<TownName.h>"
+#include "../sfall/lib.math.h"
 
 #define TOWN_REP_VAR            (GVAR_TOWN_REP_REDDING)
 
@@ -49,8 +50,7 @@ end
 procedure map_enter_p_proc begin
    CashBox_Ptr:=self_obj;
 
-   restock_fix
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       variable tmp_box := move_quest_items();
       set_local_var(LVAR_Restock_Time, (game_time + (2*ONE_GAME_WEEK)));
       check_restock_item(PID_BOTTLE_CAPS,1000,5000,100)

--- a/scripts_src/rndenctr/ectrader.ssl
+++ b/scripts_src/rndenctr/ectrader.ssl
@@ -8,6 +8,7 @@
 
 #define SCRIPT_REALNAME "ectrader"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_ECTRADER
 
@@ -84,8 +85,7 @@ procedure map_enter_p_proc begin
    if (not is_loading_game) then begin
       call ChooseItem;
 
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          check_restock_item(local_var(LVAR_Item_Pid), 1, 5, 100)
          set_local_var(LVAR_Restock_Time, (random(6,12) * ONE_GAME_DAY) + game_time);
       end

--- a/scripts_src/rndenctr/ectrappr.ssl
+++ b/scripts_src/rndenctr/ectrappr.ssl
@@ -8,6 +8,7 @@
 
 #define SCRIPT_REALNAME "ectrappr"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_ECTRAPPR
 
@@ -73,9 +74,7 @@ procedure map_enter_p_proc begin
    set_self_team(TEAM_RND_TRAPPER);
    set_self_ai(AI_GENERIC_GUARDS);
 
-   restock_fix
-
-   if (local_var(LVAR_Restock_Time) < game_time) then begin
+   if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
       check_restock_item(PID_GECKO_PELT, 5, 7, 80)
       check_restock_item(PID_GOLDEN_GECKO_PELT, 1, 5, 60)
       set_local_var(LVAR_Restock_Time, (random(6,12) * ONE_GAME_DAY) + game_time);

--- a/scripts_src/sanfran/fcdrfung.ssl
+++ b/scripts_src/sanfran/fcdrfung.ssl
@@ -28,6 +28,7 @@
 #define SCRIPT_REALNAME "fcdrfung"
 #include "../headers/define.h"
 //#include "../headers/<TownName.h>"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_FCDRFUNG
 #define TOWN_REP_VAR            (GVAR_TOWN_REP_SAN_FRANCISCO)
@@ -141,8 +142,7 @@ procedure map_enter_p_proc begin
    set_self_team(TEAM_SAN_FRAN_SHI);
    set_self_ai(AI_SF_SHI);
 
-   restock_fix
-   if (game_time > local_var(LVAR_Restock_Time)) then begin
+   if (unsigned_int_compare(game_time, local_var(LVAR_Restock_Time)) > 0) then begin
       variable tmp_box := move_quest_items();
       check_restock_item(PID_STIMPAK, 5, 7, 100)
       check_restock_item(PID_FIRST_AID_KIT, 1, 3, 60)

--- a/scripts_src/sanfran/fctnkbar.ssl
+++ b/scripts_src/sanfran/fctnkbar.ssl
@@ -28,6 +28,7 @@
 #define SCRIPT_REALNAME "fctnkbar"
 #include "../headers/define.h"
 //#include "../headers/<TownName.h>"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_FCTNKBAR
 #define TOWN_REP_VAR            (GVAR_TOWN_REP_SAN_FRANCISCO)
@@ -105,8 +106,7 @@ procedure map_enter_p_proc begin
 
    //added by killap
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          check_restock_item(PID_MUTATED_FRUIT, 1, 2, 100)
          check_restock_item(PID_BEER, 1, 5, 100)
          check_restock_item(PID_BOOZE, 2, 10, 100)

--- a/scripts_src/sanfran/figuntbl.ssl
+++ b/scripts_src/sanfran/figuntbl.ssl
@@ -20,6 +20,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "figuntbl"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_FIGUNTBL
 #define CUR_COMP_SCRIPT         SCRIPT_FIGUNTBL
@@ -151,8 +152,7 @@ procedure map_enter_p_proc begin
 
    if (validHandle(i_gun_merchant)) then begin
       ndebug("self_tile: " + self_tile);
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          if (self_tile == TABLE_1) then begin //Armor table
             ndebug("table 1 set");
             tmp_box := move_quest_items();

--- a/scripts_src/sanfran/filaotbl.ssl
+++ b/scripts_src/sanfran/filaotbl.ssl
@@ -20,6 +20,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "filaotbl"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_FILAOTBL
 #define CUR_COMP_SCRIPT         SCRIPT_FILAOTBL
@@ -149,8 +150,7 @@ procedure map_enter_p_proc begin
    variable tmp_box;
 
    if (validHandle(i_lao_merchant)) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          if (self_tile == TABLE_1) then begin //Armor table
             tmp_box := move_quest_items();
 

--- a/scripts_src/sanfran/fitguntb.ssl
+++ b/scripts_src/sanfran/fitguntb.ssl
@@ -20,6 +20,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "fitguntb"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_FITGUNTB
 #define CUR_COMP_SCRIPT         SCRIPT_FITGUNTB
@@ -145,8 +146,7 @@ end
 
 procedure map_enter_p_proc begin
    if (validHandle(MERCHANTOBJ)) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          if (self_tile == TABLE_1) then begin
             variable tmp_box := move_quest_items();
             check_restock_item(PID_BOTTLE_CAPS, 300, 436, 80)

--- a/scripts_src/sanfran/fitmertb.ssl
+++ b/scripts_src/sanfran/fitmertb.ssl
@@ -20,6 +20,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "fitmertb"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_FITMERTB
 #define CUR_COMP_SCRIPT         SCRIPT_FITMERTB
@@ -147,8 +148,7 @@ procedure map_enter_p_proc begin
    variable tmp_box;
 
    if (validHandle(MERCHANTOBJ)) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          if (self_tile == TABLE_1) then begin
             tmp_box := move_quest_items();
             check_restock_item(PID_BOTTLE_CAPS, 300, 436, 80)

--- a/scripts_src/valtcity/vidarbox.ssl
+++ b/scripts_src/valtcity/vidarbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "vidarbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_VIDARBOX
 
@@ -46,8 +47,7 @@ end
 procedure map_enter_p_proc begin
    vault_city_darrow_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 100, 500, 100)
          check_restock_item(PID_CROWBAR, 1, 1, 100)

--- a/scripts_src/valtcity/vifarbox.ssl
+++ b/scripts_src/valtcity/vifarbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "vifarbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_VIFARBOX
 
@@ -46,8 +47,7 @@ end
 procedure map_enter_p_proc begin
    vault_city_farrell_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 100, 500, 100)
          check_restock_item(PID_STIMPAK, 2, 8, 100)

--- a/scripts_src/valtcity/viharbox.ssl
+++ b/scripts_src/valtcity/viharbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "viharbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_VIHARBOX
 
@@ -49,8 +50,7 @@ procedure map_enter_p_proc begin
 
    vault_city_harry_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 150, 390, 100)
          check_restock_item(PID_KNIFE, 1, 3, 100)

--- a/scripts_src/valtcity/viranbox.ssl
+++ b/scripts_src/valtcity/viranbox.ssl
@@ -21,6 +21,7 @@
 /* Include Files */
 #define SCRIPT_REALNAME "viranbox"
 #include "../headers/define.h"
+#include "../sfall/lib.math.h"
 
 #define NAME                    SCRIPT_VIRANBOX
 
@@ -44,8 +45,7 @@ end
 procedure map_enter_p_proc begin
    vault_city_randal_box := self_obj;
    if (is_loading_game == false) then begin
-      restock_fix
-      if (local_var(LVAR_Restock_Time) < game_time) then begin
+      if (unsigned_int_compare(local_var(LVAR_Restock_Time), game_time) < 0) then begin
          variable tmp_box := move_quest_items();
          check_restock_item(PID_BOTTLE_CAPS, 200, 600, 100)
          check_restock_item(PID_BIG_BOOK_OF_SCIENCE, 1, 2, 75)


### PR DESCRIPTION
Currently I leave all `LVAR_Restock_Time_Fix` untouched in scripts. I also added `wipe_inventory` ini config support to Trader Bill in Abbey.