### PR TITLE
fcsuze: don't attempt to fight monsters, just stay in SAVE_ME_TILE

### DIFF
--- a/scripts_src/sanfran/fcsuze.ssl
+++ b/scripts_src/sanfran/fcsuze.ssl
@@ -106,6 +106,12 @@ procedure combat_p_proc begin
    if (local_var(LVAR_Follow_Dude)) then begin
       script_overrides;
       Follow_Dude(1, 2)
+   end else if (self_elevation == 1 and fixed_param == COMBAT_SUBTYPE_TURN) then begin
+      script_overrides;
+      ndebug("Stays in safe spot");
+      if (self_tile != SAVE_ME_TILE) then begin
+         animate_run_to_tile(SAVE_ME_TILE);
+      end
    end
 end
 


### PR DESCRIPTION
This fixes Suze running to hear death trying to attack the nearest Centaur on first turn. 

She's doing that because she has high enough Unarmed skill (using Vikky proto 16777588) and normal Fallout AI logic dictates that. There's no condition in default AI to check if critter should run away if it has no chance of surviving the combat. There are only simple checks like if it's HP is too low (according to AI packet) or if it can't possibly hit target. Since she can land a hit due to high skill, she will ignore any other considerations and just attack.

I think this is due to poor redesign of this map in RP. Original area looks like this, there are plenty of space between Suze and enemies.
<img width="1076" height="430" alt="image" src="https://github.com/user-attachments/assets/569c92d1-afde-41e6-a7a7-6feb2a7f8692" />
